### PR TITLE
Error checking for missing patterns

### DIFF
--- a/korg/pattern.py
+++ b/korg/pattern.py
@@ -35,6 +35,8 @@ class PatternRepo(object):
                         repl = self.pattern_dict[md['patname']]
                     # print "Replacing %s with %s"  %(md['substr'], repl)
                     pattern = pattern.replace(md['substr'],repl)
+                else:
+                    raise KeyError("Pattern '%s' not in pattern dictionary" % md['patname'])
         # print 'pattern: %s' % pattern
         return regex.compile(pattern, flags)
 

--- a/test/grok_test.py
+++ b/test/grok_test.py
@@ -292,3 +292,11 @@ def it_allows_dashes_in_capture_names():
 
     print 'subject: %s' % subject
     expect(subject["foo-bar"]).to_equal("hello")
+
+# Error checking
+
+@test
+@Vows.capture_error
+def it_raises_an_error_when_a_pattern_is_not_found():
+    pr = PatternRepo(['patterns/'])
+    expect(LineGrokker('%{SPAM_LOVELY_SPAM}', pr)).to_be_an_error_like(KeyError)


### PR DESCRIPTION
PatternRepository now raises a KeyError when it finds a pettern that is
not in the pattern dictionary.