### PR TITLE
Add check for circular search patterns

### DIFF
--- a/korg/pattern.py
+++ b/korg/pattern.py
@@ -98,7 +98,7 @@ class PatternGraph(object):
         while len(leaf_nodes):
             n = leaf_nodes.pop(0)
             for m in self.nodes[n]["out"]:
-                self.nodes[m]["in"] = list(set(self.nodes[m]["in"]) - set(n))
+                self.nodes[m]["in"] = [v for v in self.nodes[m]["in"] if v != n]
                 if not len(self.nodes[m]["in"]):
                     leaf_nodes.append(m)
             self.nodes[n]["out"] = []

--- a/korg/pattern.py
+++ b/korg/pattern.py
@@ -13,6 +13,9 @@ class PatternRepo(object):
 
     def compile_regex(self, pattern, flags=0):
         """Compile regex from pattern and pattern_dict"""
+        pattern_graph = PatternGraph(self.pattern_dict)
+        if pattern_graph.has_cycles():
+            raise Exception("Cycle found in pattern dictionary for pattern '%s'" % pattern_graph.cycle_key)
         pattern_re = regex.compile("(?P<substr>%\{(?P<fullname>(?P<patname>\w+)(?::(?P<subname>\w+))?)\})")
         while 1:
             matches = [md.groupdict() for md in pattern_re.finditer(pattern)]
@@ -59,6 +62,52 @@ class PatternRepo(object):
                     self._load_pattern_file(os.path.join(folder, file), pattern_dict)
         return pattern_dict
 
+
+class PatternGraph(object):
+    """ Create a graph from a pattern dict to check for cyclic patterns """
+
+    def __init__(self, pattern_dict):
+        self.build_nodes(pattern_dict)
+
+    def build_nodes(self, pattern_dict):
+        """ Build adjancency map """
+        pattern_re = regex.compile("(?P<substr>%\{(?P<fullname>(?P<patname>\w+)(?::(?P<subname>\w+))?)\})")
+        self.nodes = {}
+        for patname in pattern_dict:
+            matches = [md.groupdict() for md in pattern_re.finditer(pattern_dict[patname])]
+            if len(matches) == 0:
+                continue
+            if not self.nodes.has_key(patname):
+                    self.nodes[patname] = {"in": [], "out": []}
+            for md in matches:
+                if not pattern_dict.has_key(md['patname']):
+                    continue
+                if not self.nodes.has_key(md['patname']):
+                    self.nodes[md['patname']] = {"in": [], "out": []}
+                self.nodes[patname]["out"].append(md['patname'])
+                self.nodes[md['patname']]["in"].append(patname)
+        return self.nodes
+
+    def has_cycles(self):
+        leaf_nodes = []
+        # collect leaf nodes (no incoming edge)
+        for n in self.nodes:
+            if not len(self.nodes[n]["in"]):
+                leaf_nodes.append(n)
+        # Remove empty leaf nodes
+        while len(leaf_nodes):
+            n = leaf_nodes.pop(0)
+            for m in self.nodes[n]["out"]:
+                self.nodes[m]["in"] = list(set(self.nodes[m]["in"]) - set(n))
+                if not len(self.nodes[m]["in"]):
+                    leaf_nodes.append(m)
+            self.nodes[n]["out"] = []
+        # If any node connection is left, we have a circular graph
+        for n in self.nodes:
+            if len(self.nodes[n]["in"]) or len(self.nodes[n]["out"]):
+                self.cycle_key = n
+                return True
+        return False
 
 if __name__ == '__main__':
     print load_patterns(['../patterns'])


### PR DESCRIPTION
Before building the regular expression, convert search patterns into a graph and do a topological sort to
find circular patterns that would result in memory exhaustion when building the regex.