### PR TITLE
read lines support for files with \r\n

### DIFF
--- a/korg/pattern.py
+++ b/korg/pattern.py
@@ -42,7 +42,7 @@ class PatternRepo(object):
     def _load_pattern_file(self, filename, pattern_dict):
         pattern_re = regex.compile("^(?P<patname>\w+) (?P<pattern>.+)$")
         with open(filename) as f:
-            lines = f.readlines()
+            lines = f.read().splitlines()
         for line in lines:
             m = pattern_re.search(line)
             if m:


### PR DESCRIPTION
Special case for files with \r\n line breaks when running under POSIX. Apparently readlines() keeps line break and the carriage return which messes up the regex patterns.
Using splitlines() removes everything so we are good across all platforms.